### PR TITLE
Fix checking path starting with '/' on Windows

### DIFF
--- a/sphinx_gmt/gmtplot.py
+++ b/sphinx_gmt/gmtplot.py
@@ -376,7 +376,7 @@ class GMTPlotDirective(Directive):
                 code_file = Path(
                     env.app.srcdir, config.gmtplot_basedir, self.arguments[0]
                 )
-            elif Path(self.arguments[0]).is_absolute():  # relative to source directory
+            elif self.arguments[0].startswith('/'):  # relative to source directory
                 code_file = Path(env.app.srcdir, self.arguments[0][1:])
             else:  # relative to current rst file's path
                 code_file = Path(cwd, self.arguments[0])

--- a/sphinx_gmt/gmtplot.py
+++ b/sphinx_gmt/gmtplot.py
@@ -376,7 +376,7 @@ class GMTPlotDirective(Directive):
                 code_file = Path(
                     env.app.srcdir, config.gmtplot_basedir, self.arguments[0]
                 )
-            elif self.arguments[0].startswith('/'):  # relative to source directory
+            elif self.arguments[0].startswith("/"):  # relative to source directory
                 code_file = Path(env.app.srcdir, self.arguments[0][1:])
             else:  # relative to current rst file's path
                 code_file = Path(cwd, self.arguments[0])


### PR DESCRIPTION
```
.. gmt-plot:: path/to/file.sh
```
can read GMT scripts from a file. If the script path starts with `/`,  it is relative to the top source directory or relative to configuration variable `gmtplot_basedir` (if defined).

`Path.is_absolute()` can check if a path is absolute. On UNIX, it's the same as checking if it starts with `/`, but on Windows it fails.

This PR fixes the issue.