### PR TITLE
Change the docs to use README as front page

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,40 +1,52 @@
 sphinx_gmt
-============
+==========
 
-**Sphinx extensions for GMT**
+   Sphinx extensions for the Generic Mapping Tools
 
 `Documentation <https://www.generic-mapping-tools.org/sphinx_gmt>`__ |
+`Documentation (development version) <https://www.generic-mapping-tools.org/sphinx_gmt/dev>`__ |
 `Source Code <https://github.com/GenericMappingTools/sphinx_gmt>`__
-
 
 .. image:: http://img.shields.io/pypi/v/sphinx_gmt.svg?style=flat-square
     :alt: Latest version on PyPI
     :target: https://pypi.python.org/pypi/sphinx_gmt
-.. image:: http://img.shields.io/travis/GenericMappingTools/sphinx_gmt/master.svg?style=flat-square&label=linux|osx
+.. image:: http://img.shields.io/travis/GenericMappingTools/sphinx_gmt/master.svg?style=flat-square&label=TravisCI
     :alt: Travis CI build status
     :target: https://travis-ci.org/GenericMappingTools/sphinx_gmt
 .. image:: https://img.shields.io/pypi/pyversions/sphinx_gmt.svg?style=flat-square
     :alt: Compatible Python versions.
     :target: https://pypi.python.org/pypi/sphinx_gmt
 
+.. placeholder-for-doc-index
+
 
 About
 -----
 
-Sphinx extensions for inserting GMT plots in your documents and managing the GMT
-documentation.
+This package provides a `Sphinx <http://www.sphinx-doc.org/>`__ extension for
+including `GMT <http://gmt.soest.hawaii.edu/>`__ code and figures in your
+documentation. The extension defines the ``gmt-plot`` directive that
+will execute the given code and insert the generated figure into the document
+(like the `matplotlib <https://matplotlib.org/>`__ ``plot`` directive).
+
+
+Features
+--------
+
+- Supports any version of GMT
+- Works with both Bash and Python (`PyGMT <https://www.pygmt.org/>`__)
+- Include code inline or load from a script
+- Options to show/hide the code, insert captions, link to hidden code, etc.
 
 
 Contacting Us
 -------------
 
-* Most discussion happens `on Github
-  <https://github.com/GenericMappingTools/sphinx_gmt>`__. Feel free to `open an issue
-  <https://github.com/GenericMappingTools/sphinx_gmt/issues/new>`__ or comment on any
-  open issue or pull request.
-* This project is released with a `Contributor Code of Conduct
-  <https://github.com/GenericMappingTools/sphinx_gmt/blob/master/CODE_OF_CONDUCT.md>`__.
-  By participating in this project you agree to abide by its terms.
+Most discussion happens
+`on Github <https://github.com/GenericMappingTools/sphinx_gmt>`__.
+Feel free to
+`open an issue <https://github.com/GenericMappingTools/sphinx_gmt/issues/new>`__
+or comment on any open issue or pull request.
 
 
 Contributing
@@ -81,5 +93,6 @@ mistakes. That's how we all improve and we are happy to help others learn.
 License
 -------
 
-This is free software: you can redistribute it and/or modify it under the terms of the
-`BSD 3-clause License <https://github.com/GenericMappingTools/sphinx_gmt/blob/master/LICENSE.txt>`__.
+This is free software: you can redistribute it and/or modify it under the terms
+of the **BSD 3-clause License**. A copy of this license is provided in
+`LICENSE.txt <https://github.com/GenericMappingTools/sphinx_gmt/blob/master/LICENSE.txt>`__.

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -9,7 +9,7 @@ BUILDDIR      = _build
 # Internal variables.
 ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees  $(SPHINXOPTS) .
 
-.PHONY: help clean html linkcheck doctest
+.PHONY: help clean html linkcheck doctest api
 
 all: html
 
@@ -25,15 +25,22 @@ clean:
 	rm -rf $(BUILDDIR)/doctrees
 	rm -rf $(BUILDDIR)/linkcheck
 	rm -rf modules
+	rm -rf api/generated
 	rm -rf .ipynb_checkpoints
 
-html:
+html: api
 	@echo
 	@echo "Building HTML files."
 	@echo
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
+
+api:
+	@echo
+	@echo "Building API docs."
+	@echo
+	$(SPHINXAUTOGEN) -i -t _templates -o api/generated api/*.rst
 
 linkcheck:
 	$(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck

--- a/doc/_static/style.css
+++ b/doc/_static/style.css
@@ -15,6 +15,10 @@ h1 {
     font-size: 200%;
 }
 
+p.caption {
+    margin-top: 20px;
+}
+
 .gmtplot-output {
     width: 100%;
     overflow: auto;

--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -6,10 +6,6 @@ API Reference
 .. automodule:: sphinx_gmt
 
 .. autosummary::
+    :toctree: generated
 
     gmtplot
-
-gmtplot
--------
-
-.. automodule:: sphinx_gmt.gmtplot

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -3,11 +3,6 @@ import sys
 import os
 import datetime
 import sphinx_rtd_theme
-
-# Sphinx needs to be able to import the package to use autodoc and get the
-# version number
-sys.path.append(os.path.pardir)
-
 from sphinx_gmt import __version__, __commit__
 
 extensions = [
@@ -39,7 +34,7 @@ master_doc = "index"
 # General information about the project
 year = datetime.date.today().year
 project = "sphinx_gmt"
-copyright = "2018-2019, The GMT Developers"
+copyright = "2018-{}, The GMT Developers".format(year)
 if len(__version__.split("+")) > 1 or __version__ == "unknown":
     version = "dev"
 else:
@@ -72,11 +67,11 @@ html_context = {
             "https://github.com/GenericMappingTools/sphinx_gmt/blob/master/CONTRIBUTING.md",
         ),
         (
-            '<i class="fa fa-book fa-fw"></i> Code of Conduct',
+            '<i class="fa fa-gavel fa-fw"></i> Code of Conduct',
             "https://github.com/GenericMappingTools/sphinx_gmt/blob/master/CODE_OF_CONDUCT.md",
         ),
         (
-            '<i class="fa fa-gavel fa-fw"></i> License',
+            '<i class="fa fa-book fa-fw"></i> License',
             "https://github.com/GenericMappingTools/sphinx_gmt/blob/master/LICENSE.txt",
         ),
     ],
@@ -86,6 +81,7 @@ html_context = {
     "github_repo": "GenericMappingTools/sphinx_gmt",
     "github_version": "master",
 }
+
 
 # Load the custom CSS files (needs sphinx >= 1.6 for this to work)
 def setup(app):

--- a/doc/gmtplot.rst
+++ b/doc/gmtplot.rst
@@ -47,6 +47,7 @@ The following RST code:
 
     .. gmt-plot::
         :language: bash
+        :caption: Example showing how to include GMT figures with inline codes
 
         ps=example_05.ps
         gmt grdmath -R-15/15/-15/15 -I0.3 X Y HYPOT DUP 2 MUL PI MUL 8 DIV COS EXCH NEG 10 DIV EXP MUL = sombrero.nc

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -11,7 +11,7 @@ Convert this:
        :language: bash
        :show-code: false
 
-       gmt grdimage @earth_relief_15m.grd -Rg -JW10i -Baf -Cgeo > global_relief.ps
+       gmt pscoast -Rg -JW10i -Baf -Ggray > globe.ps
 
 into this:
 
@@ -20,7 +20,7 @@ into this:
     :show-code: false
     :caption: GMT plot automatically generated and included by the sphinx extension 🚀
 
-    gmt grdimage @earth_relief_15m.grd -Rg -JW10i -Baf -Cgeo > global_relief.ps
+    gmt pscoast -Rg -JW10i -Baf -Ggray > globe.ps
 
 .. include:: ../README.rst
     :start-after: placeholder-for-doc-index

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -3,24 +3,34 @@
 Sphinx extensions for the Generic Mapping Tools
 ===============================================
 
-This package provdes a `Sphinx <http://www.sphinx-doc.org/>`__ extension for
-including `GMT <http://gmt.soest.hawaii.edu/>`__ codes and figures in your
-documentation. The extension defines the ``gmt-plot`` directive that
-will execute the given code and insert the generated figure into the document.
+Convert this:
 
-Features
---------
+.. code::
 
-- Support any versions of GMT
-- Support both Bash and Python (including `PyGMT <https://www.pygmt.org/>`__) scripts
-- Support both inline codes and loading codes from a script
-- Options to show/hide the codes and link to codes if codes are hidden
+   .. gmt-plot::
+       :language: bash
+       :show-code: false
+
+       gmt grdimage @earth_relief_15m.grd -Rg -JW10i -Baf -Cgeo > global_relief.ps
+
+into this:
+
+.. gmt-plot::
+    :language: bash
+    :show-code: false
+    :caption: GMT plot automatically generated and included by the sphinx extension 🚀
+
+    gmt grdimage @earth_relief_15m.grd -Rg -JW10i -Baf -Cgeo > global_relief.ps
+
+.. include:: ../README.rst
+    :start-after: placeholder-for-doc-index
 
 .. toctree::
     :maxdepth: 2
     :caption: Documentation
+    :hidden:
 
     install.rst
     gmtplot.rst
-    api.rst
+    api/index.rst
 

--- a/sphinx_gmt/gmtplot.py
+++ b/sphinx_gmt/gmtplot.py
@@ -1,58 +1,38 @@
 """
 A directive for including a GMT plot in a Sphinx document.
 
-The source code for the GMT plot may be included in one of two ways:
-
-1.  **A path to a source file** as the argument to the directive::
-
-        .. gmt-plot:: path/to/plot.sh
-
-            Optional caption for the plot
-
-2.  Included as **inline content** to the directive::
-
-        .. gmt-plot::
-            :language: bash
-
-            gmt begin map pdf
-            gmt basemap -JX10c/10c -R0/10/0/10 -Baf
-            gmt end
-
-    In this case, the `language` option needs to be specified if the
-    language is different from `highlight_language` variable in conf.py.
-
 Options
 -------
 
 The ``gmt-plot`` directive supports the following options:
 
     show-code : bool
-        Whether to display the source code. The default can be changed
-        using the `gmtplot_show_code` variable in conf.py.
+        Whether to display the source code. The default can be changed using the
+        ``gmtplot_show_code`` variable in ``conf.py``.
 
     language : {'python', 'bash'}
-        Specify the language of the source code. The default can be changed
-        using the `highlight_language` variable in conf.py.
+        Specify the language of the source code. The default can be changed using the
+        `highlight_language` variable in conf.py.
 
     caption : str
         Caption of the rendered figure.
 
-Additionally, this directive supports options of the `figure` and
-`literalinclude` directives.
+Additionally, this directive supports options of the ``figure`` and ``literalinclude``
+directives.
 
 Configuration options
 ---------------------
 
-The ``gmt-plot`` directive has the following configuration options:
+The following options can be set in ``conf.py`` and will apply globally:
 
-    gmtplot_show_code
-        Default value for the show-code option.
+    gmtplot_show_code : bool
+        Default value for the ``show-code`` option.
 
-    gmtplot_basedir
-        Base directory, to which ``gmt-plot`` file names are relative to.
-        If None or empty, file names are relative to the directory where
-        the file containing the directive is. However, if it is absolute
-        (starting with /), it is relative to the top source directory.
+    gmtplot_basedir : str
+        Base directory, to which ``gmt-plot`` file names are relative to. If None or
+        empty, file names are relative to the directory where the file containing the
+        directive is. However, if it is absolute (starting with ``/``), it is relative
+        to the top source directory.
 
 """
 


### PR DESCRIPTION
Reuse the README so we don't have to repeat things like goals, etc.
Include a quick example in the front page as well.
Moves the API docs to sphinx-autogen and put the directive autogenerated
docs in its own page.