### PR TITLE
Rename to gmtplot and refactor Travis setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,26 +20,36 @@ env:
         - DEPLOY_DOCS=false
         - DEPLOY_PYPI=false
         - CONDA_REQUIREMENTS="requirements.txt"
+        - CONDA_INSTALL_EXTRA="sphinx=1.8.5 gmt sphinx_rtd_theme numpydoc twine"
 
 matrix:
     # Build under the following configurations
     include:
         - os: linux
+          name: "Style checks"
+          env:
+              - PYTHON=3.7
+              - CHECK=true
+              - CONDA_INSTALL_EXTRA="black pylint"
+        - os: linux
+          name: "Linux - Python 3.6 (deploy)"
           env:
               - PYTHON=3.6
-              - CHECK=true
               - BUILD_DOCS=true
               - DEPLOY_DOCS=true
               - DEPLOY_PYPI=true
         - os: linux
+          name: "Linux - Python 3.7"
           env:
               - PYTHON=3.7
               - BUILD_DOCS=true
         - os: osx
+          name: "OSX - Python 3.6"
           env:
               - PYTHON=3.6
               - BUILD_DOCS=true
         - os: osx
+          name: "OSX - Python 3.7"
           env:
               - PYTHON=3.7
               - BUILD_DOCS=true
@@ -61,7 +71,6 @@ install:
 script:
     # Check code for style and lint for code quality
     - if [ "$CHECK" == "true" ]; then
-        pip install black pylint;
         make check;
       fi
     # Build the documentation

--- a/doc/gmtplot.rst
+++ b/doc/gmtplot.rst
@@ -1,10 +1,10 @@
 .. _sphinxext:
 
-Including GMT Plots in Sphinx
+Including GMT plots in Sphinx
 =============================
 
-The extension defines the ``gmt-plot`` directive that will execute the given
-GMT codes and insert the generated figure into the document.
+The extension defines the :mod:`~sphinx_gmt.gmtplot` directive that will execute the
+given GMT codes and insert the generated figure into the document.
 
 Usage
 -----
@@ -13,7 +13,7 @@ The GMT codes may be included in one of two ways:
 
 1.  **A path to a source file** as the argument to the directive::
 
-        .. gmt-plot:: path/to/plot.sh
+        .. gmtplot:: path/to/plot.sh
 
            Optional caption for the plot
 
@@ -26,7 +26,7 @@ The GMT codes may be included in one of two ways:
 
 2.  Included as **inline content** to the directive::
 
-        .. gmt-plot::
+        .. gmtplot::
             :language: bash
 
             # place GMT codes here
@@ -45,7 +45,7 @@ The following RST code:
 
 .. code-block:: bash
 
-    .. gmt-plot::
+    .. gmtplot::
         :language: bash
         :caption: Example showing how to include GMT figures with inline codes
 
@@ -60,7 +60,7 @@ The following RST code:
 
 is executed by sphinx and turned into:
 
-.. gmt-plot::
+.. gmtplot::
     :language: bash
     :caption: Example showing how to include GMT figures with inline codes
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -7,7 +7,7 @@ Convert this:
 
 .. code::
 
-   .. gmt-plot::
+   .. gmtplot::
        :language: bash
        :show-code: false
 
@@ -15,7 +15,7 @@ Convert this:
 
 into this:
 
-.. gmt-plot::
+.. gmtplot::
     :language: bash
     :show-code: false
     :caption: GMT plot automatically generated and included by the sphinx extension 🚀

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -16,7 +16,6 @@ Dependencies
 * `GMT <http://gmt.soest.hawaii.edu/>`__
 * `sphinx <http://www.sphinx-doc.org>`__
 * `jinja2 <http://jinja.pocoo.org/>`__
-* `ipython <https://ipython.org/>`__
 
 
 Installing the latest development version

--- a/environment.yml
+++ b/environment.yml
@@ -7,9 +7,8 @@ dependencies:
     - pip
     - gmt
     - jinja2
-    - ipython
-    - sphinx
+    - sphinx=1.8.5
     - sphinx_rtd_theme
     - numpydoc
     - black
-    - twine
+    - pylint

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,2 @@
 jinja2
-ipython
 sphinx
-# Development requirements
-gmt
-sphinx_rtd_theme
-numpydoc
-twine

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ import versioneer
 
 
 NAME = "sphinx_gmt"
-FULLNAME = "GMT Sphinx Ext"
+FULLNAME = "GMT Sphinx Extensions"
 AUTHOR = "Leonardo Uieda"
 AUTHOR_EMAIL = "leouieda@gmail.com"
 MAINTAINER = AUTHOR
@@ -38,7 +38,7 @@ CLASSIFIERS = [
 ]
 PLATFORMS = "Any"
 PYTHON_REQUIRES = ">=3.6"
-INSTALL_REQUIRES = ["jinja2", "ipython", "sphinx"]
+INSTALL_REQUIRES = ["jinja2", "sphinx"]
 
 if __name__ == "__main__":
     setup(

--- a/sphinx_gmt/gmtplot.py
+++ b/sphinx_gmt/gmtplot.py
@@ -4,7 +4,7 @@ A directive for including a GMT plot in a Sphinx document.
 Options
 -------
 
-The ``gmt-plot`` directive supports the following options:
+The ``gmtplot`` directive supports the following options:
 
     show-code : bool
         Whether to display the source code. The default can be changed using the
@@ -29,7 +29,7 @@ The following options can be set in ``conf.py`` and will apply globally:
         Default value for the ``show-code`` option.
 
     gmtplot_basedir : str
-        Base directory, to which ``gmt-plot`` file names are relative to. If None or
+        Base directory, to which ``gmtplot`` file names are relative to. If None or
         empty, file names are relative to the directory where the file containing the
         directive is. However, if it is absolute (starting with ``/``), it is relative
         to the top source directory.
@@ -286,7 +286,7 @@ def get_suffix_from_language(language):
 
 class GMTPlotDirective(Directive):
     """
-    The gmt-plot directive implementation.
+    The gmtplot directive implementation.
     """
 
     has_content = True
@@ -435,13 +435,13 @@ class GMTPlotDirective(Directive):
 
 def setup(app):
     """
-    Add the gmt-plot directive to the sphinx app.
+    Add the gmtplot directive to the sphinx app.
     """
     setup.app = app
     setup.config = app.config
     setup.confdir = app.confdir
 
-    app.add_directive("gmt-plot", GMTPlotDirective)
+    app.add_directive("gmtplot", GMTPlotDirective)
     app.add_config_value("gmtplot_basedir", None, True)
     app.add_config_value("gmtplot_show_code", True, True)
     app.add_config_value("gmtplot_figure_align", "center", True)


### PR DESCRIPTION
Modernize our TravisCI setup and use sphinx 1.8.5 to build the docs
because of an error formatting numpydoc style parameter lists. Remove
the ipython dependency which isn't used anywhere.

Fixes #19