### PR TITLE
Add a changelog and links to previous versions

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -1,0 +1,13 @@
+.. _changes:
+
+Changelog
+=========
+
+Version 0.1.0
+-------------
+
+*Released on: 2019/06/21*
+
+* First release of ``sphinx_gmt`` with the ``gmtplot`` directive for automatically
+  generating GMT plots and inserting them into Sphinx generated documentation. Supports
+  multiple GMT versions, bash, and Python (through PyGMT).

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -41,7 +41,7 @@ else:
     version = __version__
 
 html_last_updated_fmt = "%b %d, %Y"
-html_title = project
+html_title = "Sphinx Extensions for GMT"
 html_short_title = project
 html_logo = ""
 html_favicon = "_static/favicon.png"

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -33,4 +33,6 @@ into this:
     install.rst
     gmtplot.rst
     api/index.rst
+    releases.rst
+    changes.rst
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -18,6 +18,23 @@ Dependencies
 * `jinja2 <http://jinja.pocoo.org/>`__
 
 
+Installing with conda
+---------------------
+
+You can install ``sphinx_gmt`` using the `conda package manager <https://conda.io/>`__
+that comes with the Anaconda distribution::
+
+    conda install sphinx_gmt --channel conda-forge
+
+
+Installing with pip
+-------------------
+
+Alternatively, you can also use the `pip package manager <https://pypi.org/project/pip/>`__::
+
+    pip install sphinx_gmt
+
+
 Installing the latest development version
 -----------------------------------------
 

--- a/doc/releases.rst
+++ b/doc/releases.rst
@@ -1,0 +1,11 @@
+.. _releases:
+
+Previous versions
+=================
+
+Documentation for previous releases and the current development version (reflecting the
+*master* branch on Github) can be found at:
+
+* `Development <https://www.generic-mapping-tools.org/sphinx_gmt/dev>`__
+* `Latest release <https://www.generic-mapping-tools.org/sphinx_gmt/latest>`__
+* `v0.1.0 <https://www.generic-mapping-tools.org/sphinx_gmt/v0.1.0>`__


### PR DESCRIPTION
Start the changelog in `doc/changes.rst` and include a page linking to other versions of
the documentation. The version number for the first release will be 0.1.0.