### PR TITLE
Disable displaying figure when gmt end show is used

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -3,6 +3,13 @@
 Changelog
 =========
 
+Version 0.1.1
+-------------
+
+*Released on: 2019/09/16*
+
+* Disable displaying figure when ``gmt end show`` is used (#26)
+
 Version 0.1.0
 -------------
 

--- a/doc/releases.rst
+++ b/doc/releases.rst
@@ -8,4 +8,5 @@ Documentation for previous releases and the current development version (reflect
 
 * `Development <https://www.generic-mapping-tools.org/sphinx_gmt/dev>`__
 * `Latest release <https://www.generic-mapping-tools.org/sphinx_gmt/latest>`__
+* `v0.1.1 <https://www.generic-mapping-tools.org/sphinx_gmt/v0.1.1>`__
 * `v0.1.0 <https://www.generic-mapping-tools.org/sphinx_gmt/v0.1.0>`__

--- a/sphinx_gmt/gmtplot.py
+++ b/sphinx_gmt/gmtplot.py
@@ -163,6 +163,13 @@ def eval_bash(code, code_dir, output_dir, output_base):
     Execute a multi-line block of bash code and copy the generated image files
     to specified output directory.
     """
+    # Change "gmt end show" to "gmt end" to avoid displaying figures
+    lines = code.splitlines()
+    for i in range(len(lines)):
+        if lines[i].split() == ["gmt", "end", "show"]:
+            lines[i] = "gmt end"
+    code = "\n".join(lines)
+
     with tempfile.TemporaryDirectory() as tmpdir:
         Path(tmpdir, "script.sh").write_text(code, encoding="utf-8")
 


### PR DESCRIPTION
`gmt end show` always opens generated figures, which is not suitable when we generating a HTML website. This PR searches for `gmt end show` in bash scripts and replaces it with `gmt end` instead.