### PR TITLE
add_stylesheet is deprecated, use html_css_files

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -47,6 +47,7 @@ html_short_title = project
 html_logo = ""
 html_favicon = "_static/favicon.png"
 html_static_path = ["_static"]
+html_css_files = ["style.css"]
 html_extra_path = [".nojekyll"]
 pygments_style = "default"
 add_function_parentheses = False
@@ -82,8 +83,3 @@ html_context = {
     "github_repo": "GenericMappingTools/sphinx_gmt",
     "github_version": "master",
 }
-
-
-# Load the custom CSS files (needs sphinx >= 1.6 for this to work)
-def setup(app):
-    app.add_stylesheet("style.css")


### PR DESCRIPTION
<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss. -->
<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
**Description of proposed changes**

Use `html_css_files` instead of `add_stylesheet`.

References: https://www.sphinx-doc.org/en/master/usage/configuration.html

Needs Sphinx >= 1.8


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
