### PR TITLE
Add an example page showing both classic and modern modes GMT bash scripts

### DIFF
--- a/doc/example-gmt.sh
+++ b/doc/example-gmt.sh
@@ -1,0 +1,3 @@
+gmt begin GMT_orthographic png
+    gmt coast -Rg -JG-75/41/12c -Bg -Dc -A5000 -Gpink -Sthistle
+gmt end show

--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -1,45 +1,11 @@
-.. _sphinxext:
-
-Including GMT plots in Sphinx
-=============================
-
-The extension defines the :mod:`~sphinx_gmt.gmtplot` directive that will execute the
-given GMT codes and insert the generated figure into the document.
-
-Usage
------
-
-The GMT codes may be included in one of two ways:
-
-1.  **A path to a source file** as the argument to the directive::
-
-        .. gmtplot:: path/to/plot.sh
-
-           Optional caption for the plot
-
-    The source file name is usually relative to the current file's path.
-    However, if it is absolute (starting with ``/``), it is relative to
-    the top source directory.
-
-    In this way, it will try to guess the script language from its file suffix.
-    Supported suffixes are ``.sh``, ``.bash`` and ``.py``.
-
-2.  Included as **inline content** to the directive::
-
-        .. gmtplot::
-            :language: bash
-
-            # place GMT codes here
-            gmt ...
-            gmt ...
-            gmt ...
-
-    In this way, you have to let it know the script language by providing
-    the ``:language:`` option.
-
-
 Examples
---------
+========
+
+The ``gmtplot`` directive supports any GMT versions, and both Bash and Python
+scripts.
+
+Classic GMT bash script
+-----------------------
 
 The following RST code:
 
@@ -72,3 +38,26 @@ is executed by sphinx and turned into:
     echo "4.1 5.5 z(r) = cos (2@~p@~r/8) @~\327@~e@+-r/10@+" | gmt pstext -R0/11/0/8.5 -Jx1i \
 	    -F+f50p,ZapfChancery-MediumItalic+jBC -O >> $ps
     rm -f g.cpt sombrero.nc
+
+
+Modern GMT bash script
+----------------------
+
+We have a modern GMT bash script ``example-gmt.sh`` in the current directory.
+Its content is:
+
+.. literalinclude:: example-gmt.sh
+
+The following RST code:
+
+.. code-block:: bash
+
+    .. gmtplot:: example-gmt.sh
+        :width: 30%
+        :caption: GMT Orthographic projection
+
+is executed by sphinx and turned into:
+
+.. gmtplot:: example-gmt.sh
+    :width: 50%
+    :caption: GMT Orthographic projection

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -10,6 +10,7 @@ Convert this:
    .. gmtplot::
        :language: bash
        :show-code: false
+       :caption: GMT plot automatically generated and included by the sphinx extension 🚀
 
        gmt pscoast -Rg -JW10i -Baf -Ggray > globe.ps
 
@@ -31,7 +32,8 @@ into this:
     :hidden:
 
     install.rst
-    gmtplot.rst
+    usage.rst
+    examples.rst
     api/index.rst
     releases.rst
     changes.rst

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -1,0 +1,33 @@
+Usage
+=====
+
+The extension defines the :mod:`~sphinx_gmt.gmtplot` directive that will execute the
+given GMT codes and insert the generated figure into the document.
+
+The GMT codes may be included in one of two ways:
+
+1.  **A path to a source file** as the argument to the directive::
+
+        .. gmtplot:: path/to/plot.sh
+
+           Optional caption for the plot
+
+    The source file name is usually relative to the current file's path.
+    However, if it is an absolute path starting with ``/``, it is relative to
+    the top source directory.
+
+    In this way, the directive will try to guess the script language from its
+    file suffix. Supported suffixes are ``.sh``, ``.bash`` and ``.py``.
+
+2.  Included as **inline content** to the directive::
+
+        .. gmtplot::
+            :language: bash
+
+            # place GMT codes here
+            gmt ...
+            gmt ...
+            gmt ...
+
+    In this way, you have to let it know the script language by providing
+    the ``:language:`` option.


### PR DESCRIPTION
**Description of proposed changes**

Split the old `gmtplot.rst` file into two files `usage.rst` and `examples.rst`, and add one more example for GMT modern-mode bash script.